### PR TITLE
Build fix: Don't try to copy SimpleITKCSharpNative.dll if it hasn't been downloaded yet

### DIFF
--- a/GodotVolumetricRendering.csproj
+++ b/GodotVolumetricRendering.csproj
@@ -5,7 +5,7 @@
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'ios' ">net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(GodotTargetPlatform)' == 'windows' and Exists('lib\SimpleITK\SimpleITKCSharpNative.dll')">
     <Content Include="lib\SimpleITK\SimpleITKCSharpNative.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fixes #5

Build fix: Don't try to copy native SimpleITK DLL if it hasn't been downloaded yet.

Also added a platform-dependent condition, so we don't try to copy SimpleITKCSharpNative.dll on Linux&MacOS.

Sorry for my PR chaos today 😅 I'm still new to Godot, but I'm learning!